### PR TITLE
[Feat] #26 chat flow 변경

### DIFF
--- a/frontend/src/components/features/CardMediaLeft.tsx
+++ b/frontend/src/components/features/CardMediaLeft.tsx
@@ -24,6 +24,7 @@ export default function CardMediaLeft({
   isOpen = true,
 }: CardMediaLeftProps) {
   const [showModal, setShowModal] = useState(false);
+  const [imageError, setImageError] = useState(false);
   const hasTags = tags.length > 0;
   const hasDescription = description && description.trim().length > 0;
   const showArrowRight = hasDescription && !hasTags; // 설명이 있고 태그가 없을 때만 화살표 표시
@@ -36,34 +37,38 @@ export default function CardMediaLeft({
     }
   };
 
+  const getImageUrl = (): string | undefined => {
+    if (!imageUrl || imageError) return undefined;
+    return imageUrl.startsWith("/assets/images/")
+      ? new URL(".." + imageUrl, import.meta.url).href
+      : imageUrl;
+  };
+
   return (
-    <>
+    <div className="w-full flex flex-col">
       <div
         className={cn(
-          "w-full inline-flex justify-start items-center gap-3",
+          "w-full inline-flex justify-start items-start gap-3",
           onClick && isOpen && "cursor-pointer",
           className
         )}
         onClick={handleClick}
       >
-        {/* 이미지 */}
-        <div
-          className="w-20 h-20 relative bg-indigo-900 rounded"
-          style={{
-            backgroundImage: imageUrl
-              ? imageUrl.startsWith("/assets/images/")
-                ? `url(${new URL(".." + imageUrl, import.meta.url).href})`
-                : `url(${imageUrl})`
-              : undefined,
-            backgroundSize: "cover",
-            backgroundPosition: "center",
-          }}
-        >
+        {/* image */}
+        <div className="w-20 h-20 relative bg-indigo-900 rounded overflow-hidden">
+          {getImageUrl() && (
+            <img
+              src={getImageUrl()}
+              alt={name}
+              className="w-full h-full object-cover"
+              onError={() => setImageError(true)}
+            />
+          )}
+
+          {/* gradient overlay */}
           {!isOpen && (
             <>
-              {/* gradient overlay */}
               <div className="absolute inset-0 w-full h-full bg-gradient-to-b from-black/90 via-black/70 to-black/0 pointer-events-none" />
-              {/* 중앙 아이콘 */}
               <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center">
                 <div className="w-8 h-8 bg-gray-400/40 rounded-full flex items-center justify-center">
                   <div className="w-3 h-4 bg-Font-White-Font">
@@ -75,37 +80,29 @@ export default function CardMediaLeft({
           )}
         </div>
 
-        {/* 콘텐츠 영역 */}
+        {/* content */}
         <div className="flex-1 inline-flex flex-col justify-start items-start gap-2">
-          {/* 제목 행 */}
           <div className="self-stretch inline-flex justify-between items-center">
             <div className="text-white text-base font-semibold">{name}</div>
             {showArrowRight && <ArrowRight className="w-5 h-5 text-gray-300" />}
           </div>
-
-          {/* 칩 또는 설명 */}
-          {hasTags && (
-            <div className="flex flex-wrap gap-1">
-              {tags.slice(0, 2).map((tag, index) => (
-                <Chip
-                  key={index}
-                  size="m"
-                  shape="rounded"
-                  variantStyle="filled"
-                >
-                  {tag}
-                </Chip>
-              ))}
-            </div>
-          )}
-
-          {hasDescription && !hasTags && (
-            <div className="self-stretch text-white text-sm font-normal leading-tight line-clamp-2">
-              {description}
-            </div>
-          )}
+          <div className="self-stretch text-white text-sm font-normal leading-tight line-clamp-2">
+            {description}
+          </div>
         </div>
       </div>
+
+      {/* tags */}
+      {hasTags && (
+        <div className="w-full flex flex-wrap gap-1 mt-2">
+          {tags.slice(0, 2).map((tag, index) => (
+            <Chip key={index} size="m" shape="rounded" variantStyle="filled">
+              {tag}
+            </Chip>
+          ))}
+        </div>
+      )}
+
       {showModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="bg-white rounded-lg shadow-lg p-6 min-w-[220px] flex flex-col items-center">
@@ -122,6 +119,6 @@ export default function CardMediaLeft({
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/features/CharacterChatTab.tsx
+++ b/frontend/src/components/features/CharacterChatTab.tsx
@@ -1,0 +1,41 @@
+import CardMediaLeft from "./CardMediaLeft";
+import type { Character } from "@/types/character";
+import type { Background } from "@/types/background";
+
+interface CharacterChatTabProps {
+  character: Character;
+  backgrounds: Background[];
+  hasChatHistory: boolean;
+  onBackgroundClick: (backgroundId: string) => void;
+}
+
+export default function CharacterChatTab({
+  character,
+  backgrounds,
+  hasChatHistory,
+  onBackgroundClick,
+}: CharacterChatTabProps) {
+  return (
+    <div>
+      {hasChatHistory ? (
+        <div className="flex flex-col gap-4">
+          {backgrounds.map((background: Background) => (
+            <CardMediaLeft
+              key={background.backgroundId}
+              imageUrl="src/assets/images/characters/character_1.png"
+              name={background.backgroundName}
+              description={background.description}
+              onClick={() => onBackgroundClick(background.backgroundId)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex justify-center p-10">
+          <p className="text-gray-400">
+            아직 {character.name}와 채팅하지 않았어요.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/features/CharacterDescriptionTab.tsx
+++ b/frontend/src/components/features/CharacterDescriptionTab.tsx
@@ -1,0 +1,86 @@
+import Chip from "@/components/ui/Chip";
+import CharacterInfoSection from "./CharacterInfoSection";
+import CardMediaTop from "./CardMediaTop";
+import { ReactComponent as PenIcon } from "@/assets/icons/Pen.svg";
+import type { Character } from "@/types/character";
+import type { Background } from "@/types/background";
+
+interface CharacterDescriptionTabProps {
+  character: Character;
+  backgrounds: Background[];
+  hasChatHistory: boolean;
+  onBackgroundClick: (backgroundId: string) => void;
+}
+
+export default function CharacterDescriptionTab({
+  character,
+  backgrounds,
+  hasChatHistory,
+  onBackgroundClick,
+}: CharacterDescriptionTabProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <CharacterInfoSection
+          title="외모 및 성격"
+          content={character.personality}
+        />
+        <CharacterInfoSection title="특징" content={character.traits} />
+        <CharacterInfoSection title="말투" content={character.dialogueStyle} />
+      </div>
+
+      {/* Comment Area */}
+      <div>
+        <div className="flex items-center gap-1 mb-2">
+          <Chip
+            size="l"
+            variantStyle="outlined"
+            shape="square"
+            rightIcon={<PenIcon className="text-safe" />}
+            className="bg-gray-900"
+          >
+            {character.writerName}
+          </Chip>
+        </div>
+        <p className="text-sm text-normal text-White-Font whitespace-pre-line">
+          {character.writerNote}
+        </p>
+      </div>
+
+      {/* Background Area */}
+      <div className="gap-6 flex flex-col">
+        {hasChatHistory ? (
+          <CharacterInfoSection
+            title="배경 설명"
+            content={character.dialogueStyle}
+          />
+        ) : (
+          <></>
+        )}
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col items-start">
+            <h2 className="text-lg font-semibold">또 다른 배경 보기</h2>
+            <p className="text-sm text-gray-500">
+              🔒 캐릭터와 채팅이 쌓이면 잠금된 배경을 볼 수 있어요.
+            </p>
+          </div>
+          <div className="overflow-x-auto flex gap-4 scrollbar-hide">
+            {backgrounds.map((background: Background) => {
+              return (
+                <CardMediaTop
+                  key={background.backgroundId}
+                  imageUrl="src/assets/images/backgrounds/library.png"
+                  name={background.backgroundName}
+                  chips={background.tags}
+                  onClick={() => onBackgroundClick(background.backgroundId)}
+                  variant="horizontal"
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/features/CharacterDetailTabs.tsx
+++ b/frontend/src/components/features/CharacterDetailTabs.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import CharacterDescriptionTab from "./CharacterDescriptionTab";
+import CharacterChatTab from "./CharacterChatTab";
+import type { Character } from "@/types/character";
+import type { Background } from "@/types/background";
+
+interface CharacterDetailTabsProps {
+  character: Character;
+  backgrounds: Background[];
+  hasChatHistory: boolean;
+  onBackgroundClick: (backgroundId: string) => void;
+}
+
+export default function CharacterDetailTabs({
+  character,
+  backgrounds,
+  hasChatHistory,
+  onBackgroundClick,
+}: CharacterDetailTabsProps) {
+  const [activeTab, setActiveTab] = useState<"description" | "chat">(
+    "description"
+  );
+
+  return (
+    <>
+      {/* Tabs */}
+      <div className="px-4">
+        <div className="flex">
+          <button
+            onClick={() => setActiveTab("description")}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+              activeTab === "description"
+                ? "text-White-Font border-b-2 border-primary"
+                : "text-gray-400"
+            }`}
+          >
+            캐릭터 설명
+          </button>
+          <button
+            onClick={() => setActiveTab("chat")}
+            className={`flex-1 py-3 text-sm font-normal transition-colors ${
+              activeTab === "chat"
+                ? "text-White-Font border-b-2 border-primary"
+                : "text-gray-400"
+            }`}
+          >
+            이전 채팅
+          </button>
+        </div>
+      </div>
+
+      {/* Tab Content */}
+      <div className="px-4 py-4 mb-16">
+        {activeTab === "description" ? (
+          <CharacterDescriptionTab
+            character={character}
+            backgrounds={backgrounds}
+            hasChatHistory={hasChatHistory}
+            onBackgroundClick={onBackgroundClick}
+          />
+        ) : (
+          <CharacterChatTab
+            character={character}
+            backgrounds={backgrounds}
+            hasChatHistory={hasChatHistory}
+            onBackgroundClick={onBackgroundClick}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/BackgroundDetail.tsx
+++ b/frontend/src/pages/BackgroundDetail.tsx
@@ -76,43 +76,35 @@ const BackgroundDetail: React.FC = () => {
 
   return (
     <div className="min-h-screen">
-      <Header variant="withText" title={background.backgroundName} />
+      <Header variant="withText" title="작품 확인" />
 
       <div className="pt-14 pb-36">
         {/* Background Section */}
         <div className="relative flex flex-col p-4 gap-3">
           {/* Background Image */}
-          <div className="relative w-full h-full aspect-square">
-            <div className="w-full h-90 bg-gradient-to-b from-purple-600 via-purple-500 to-indigoGray-black" />
-            {/* Gradient Overlay */}
-            <div className="absolute inset-0 w-full h-90 bg-gradient-to-t from-indigoGray-black via-transparent to-transparent" />
+          <div className="relative w-full aspect-square">
+            {/* Fallback gradient background */}
+            <div className="absolute inset-0 w-full h-full bg-gradient-to-b from-purple-600 via-purple-500 to-indigoGray-black" />
+
+            {/* Background Image */}
             <img
-              // src={background.backgroundImg || "/image/icon.png"}
               src="/src/assets/images/backgrounds/library.png"
               alt="Background Image"
-              className="w-full h-90 object-cover aspect-square"
+              className="absolute inset-0 w-full h-full object-cover"
               onError={(e) => {
                 (e.currentTarget as HTMLImageElement).src = "/image/icon.png";
               }}
             />
-          </div>
 
+            {/* Gradient Overlay */}
+            <div className="absolute inset-0 w-full h-full bg-gradient-to-t from-indigoGray-black via-transparent to-transparent" />
+          </div>
           {/* Background Info */}
           <div className="flex flex-col gap-2">
             <h1 className="text-2xl font-bold text-White-Font ">
-              {background.backgroundName}
+              {background.backgroundName}와 {background.backgroundName}에서
+              대화하기
             </h1>
-            <div className="flex gap-1 flex-wrap">
-              {background.tags.length > 0 ? (
-                background.tags.map((tag, index) => (
-                  <Chip key={index} size="m">
-                    {tag}
-                  </Chip>
-                ))
-              ) : (
-                <Chip size="m">배경</Chip>
-              )}
-            </div>
           </div>
           {/* Background Description */}
           <div>
@@ -123,7 +115,7 @@ const BackgroundDetail: React.FC = () => {
         </div>
       </div>
 
-      <FloatingButton buttonlabel="다음" onClick={handleChatClick} />
+      <FloatingButton buttonlabel="채팅 시작" onClick={handleChatClick} />
       <BottomNav />
     </div>
   );

--- a/frontend/src/pages/Backgrounds.tsx
+++ b/frontend/src/pages/Backgrounds.tsx
@@ -24,7 +24,7 @@ const Backgrounds: React.FC = () => {
     if (userId && writerId) {
       get(`/users/${userId}/background-flows-with-opened?writerId=${writerId}`);
     }
-  }, [get]);
+  }, [get, userId, writerId]);
 
   const flows = backgroundsData?.data?.flows || [];
   const steps = flows.length > 0 ? flows[0].steps : [];
@@ -78,6 +78,7 @@ const Backgrounds: React.FC = () => {
                 id: step.backgroundId,
                 name: step.backgroundName,
                 imageUrl: step.backgroundImg || "/image/icon.png",
+                description: step.backgroundDescription || "설명이 없습니다.",
                 tags: step.tags && step.tags.length > 0 ? step.tags : ["배경"],
                 isOpen: step.isOpened,
               }))}

--- a/frontend/src/pages/CharacterDetail.tsx
+++ b/frontend/src/pages/CharacterDetail.tsx
@@ -1,18 +1,14 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useApi } from "@/hooks/useApi";
 import { useParams, useNavigate } from "react-router-dom";
 import Header from "@/components/layout/Header";
 import BottomNav from "@/components/layout/BottomNav";
 import FloatingButton from "@/components/features/FloatingButton";
 import Chip from "@/components/ui/Chip";
+import CharacterDetailTabs from "@/components/features/CharacterDetailTabs";
 import { ReactComponent as LikeIcon } from "@/assets/icons/Like.svg";
 import { ReactComponent as ChatIcon } from "@/assets/icons/Chat.svg";
-import { ReactComponent as PenIcon } from "@/assets/icons/Pen.svg";
-import CardMediaTop from "@/components/features/CardMediaTop";
-import CharacterInfoSection from "@/components/features/CharacterInfoSection";
 import { useFlowStore } from "@/stores/useFlowStore";
-import type { Background } from "@/types/background";
-import CardMediaLeft from "@/components/features/CardMediaLeft";
 
 const mockCharacter = {
   likeCount: 24,
@@ -23,9 +19,6 @@ const getImageUrl = (dbPath: string) =>
   new URL(`../assets/images/${dbPath}`, import.meta.url).href;
 
 export default function CharacterDetailPage() {
-  const [activeTab, setActiveTab] = useState<"description" | "chat">(
-    "description"
-  );
   const { setCharacter, setWriter } = useFlowStore();
   const navigate = useNavigate();
   const { charId } = useParams();
@@ -45,10 +38,7 @@ export default function CharacterDetailPage() {
     loading: backgroundLoading,
     error: backgroundError,
     get: getBackground,
-  } = useApi<{
-    success: boolean;
-    data: import("@/types/background").Background;
-  }>();
+  } = useApi<import("@/types/background").BackgroundListResponse>();
 
   useEffect(() => {
     getBackground("/backgrounds");
@@ -153,136 +143,13 @@ export default function CharacterDetailPage() {
           </div>
         </div>
 
-        {/* Tabs */}
-        <div className="px-4">
-          <div className="flex">
-            <button
-              onClick={() => setActiveTab("description")}
-              className={`flex-1 py-3 text-sm font-medium transition-colors ${
-                activeTab === "description"
-                  ? "text-White-Font border-b-2 border-primary"
-                  : "text-gray-400"
-              }`}
-            >
-              캐릭터 설명
-            </button>
-            <button
-              onClick={() => setActiveTab("chat")}
-              className={`flex-1 py-3 text-sm font-normal transition-colors ${
-                activeTab === "chat"
-                  ? "text-White-Font border-b-2 border-primary"
-                  : "text-gray-400"
-              }`}
-            >
-              이전 채팅
-            </button>
-          </div>
-        </div>
-
-        {/* Tab Content */}
-        <div className="px-4 py-4 mb-16">
-          {activeTab === "description" ? (
-            <div className="space-y-6">
-              <div className="space-y-4">
-                <CharacterInfoSection
-                  title="외모 및 성격"
-                  content={character.personality}
-                />
-                <CharacterInfoSection title="특징" content={character.traits} />
-                <CharacterInfoSection
-                  title="말투"
-                  content={character.dialogueStyle}
-                />
-              </div>
-              {/* -------------------------- */}
-
-              {/* Comment Area */}
-              <div>
-                <div className="flex items-center gap-1 mb-2">
-                  <Chip
-                    size="l"
-                    variantStyle="outlined"
-                    shape="square"
-                    rightIcon={<PenIcon className="text-safe" />}
-                    className="bg-gray-900"
-                  >
-                    {character.writerName}
-                  </Chip>
-                </div>
-                <p className="text-sm text-normal text-White-Font whitespace-pre-line">
-                  {character.writerNote}
-                </p>
-              </div>
-
-              {/* Background Area */}
-              <div className="gap-6 flex flex-col">
-                {hasChatHistory ? (
-                  <CharacterInfoSection
-                    title="배경 설명"
-                    content={character.dialogueStyle}
-                  />
-                ) : (
-                  <></>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <div className="flex flex-col items-start">
-                    <h2 className="text-lg font-semibold">또 다른 배경 보기</h2>
-                    <p className="text-sm text-gray-500">
-                      🔒 캐릭터와 채팅이 쌓이면 잠금된 배경을 볼 수 있어요.
-                    </p>
-                  </div>
-                  <div className="overflow-x-auto flex gap-4 scrollbar-hide">
-                    {/* {background.isLocked && (
-                      <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
-                        <LockIcon className="w-10 h-10 text-gray-400" />
-                      </div>
-                    )} */}
-                    {/* cards={backgrounds.map(transformBackgroundData)} */}
-                    {backgrounds.map((background: Background, idx: number) => {
-                      return (
-                        <CardMediaTop
-                          key={background.backgroundId}
-                          imageUrl="src/assets/images/backgrounds/library.png"
-                          name={background.backgroundName}
-                          chips={background.tags}
-                          onClick={() =>
-                            handleBackgroundClick(background.backgroundId)
-                          }
-                          variant="horizontal"
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div>
-              {hasChatHistory ? (
-                <div className="flex flex-col gap-4">
-                  {backgrounds.map((background: Background) => (
-                    <CardMediaLeft
-                      key={background.backgroundId}
-                      imageUrl="src/assets/images/characters/character_1.png"
-                      name={background.backgroundName}
-                      description={background.description}
-                      onClick={() =>
-                        handleBackgroundClick(background.backgroundId)
-                      }
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div className="flex justify-center p-10">
-                  <p className="text-gray-400">
-                    아직 {character.name}와 채팅하지 않았어요.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
+        {/* Character Detail Tabs */}
+        <CharacterDetailTabs
+          character={character}
+          backgrounds={backgrounds}
+          hasChatHistory={hasChatHistory}
+          onBackgroundClick={handleBackgroundClick}
+        />
       </div>
       <FloatingButton
         like={true}

--- a/frontend/src/pages/CharacterDetail.tsx
+++ b/frontend/src/pages/CharacterDetail.tsx
@@ -12,6 +12,7 @@ import CardMediaTop from "@/components/features/CardMediaTop";
 import CharacterInfoSection from "@/components/features/CharacterInfoSection";
 import { useFlowStore } from "@/stores/useFlowStore";
 import type { Background } from "@/types/background";
+import CardMediaLeft from "@/components/features/CardMediaLeft";
 
 const mockCharacter = {
   likeCount: 24,
@@ -89,6 +90,14 @@ export default function CharacterDetailPage() {
     return <div>배경 정보를 불러올 수 없습니다.</div>;
   }
 
+  // -------------------------------------------------------
+  // const hasChatHistory =
+  //   character.chatHistory && character.chatHistory.length > 0;
+  // chatHistory 연결 필요
+  // chat history가 없을 경우 배경 설명 추가, 채팅하기 누를 시 바로 페르소나로 이동
+  const hasChatHistory = true;
+
+  // -------------------------------------------------------
   const handleChatClick = () => {
     setCharacter(character.characterId);
     setWriter(character.writerId);
@@ -206,38 +215,71 @@ export default function CharacterDetailPage() {
               </div>
 
               {/* Background Area */}
-              <div className="gap-3 flex flex-col">
-                <h2 className="text-lg font-semibold">볼 수 있는 배경</h2>
-                <div className="overflow-x-auto flex gap-4 scrollbar-hide">
-                  {/* {background.isLocked && (
+              <div className="gap-6 flex flex-col">
+                {hasChatHistory ? (
+                  <CharacterInfoSection
+                    title="배경 설명"
+                    content={character.dialogueStyle}
+                  />
+                ) : (
+                  <></>
+                )}
+
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-col items-start">
+                    <h2 className="text-lg font-semibold">또 다른 배경 보기</h2>
+                    <p className="text-sm text-gray-500">
+                      🔒 캐릭터와 채팅이 쌓이면 잠금된 배경을 볼 수 있어요.
+                    </p>
+                  </div>
+                  <div className="overflow-x-auto flex gap-4 scrollbar-hide">
+                    {/* {background.isLocked && (
                       <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
                         <LockIcon className="w-10 h-10 text-gray-400" />
                       </div>
                     )} */}
-                  {/* cards={backgrounds.map(transformBackgroundData)} */}
-                  {backgrounds.map((background: Background, idx: number) => {
-                    return (
-                      <CardMediaTop
-                        key={background.backgroundId}
-                        imageUrl="src/assets/images/backgrounds/library.png"
-                        name={background.backgroundName}
-                        chips={background.tags}
-                        isOpen={idx < 2}
-                        onClick={() =>
-                          handleBackgroundClick(background.backgroundId)
-                        }
-                        variant="horizontal"
-                      />
-                    );
-                  })}
+                    {/* cards={backgrounds.map(transformBackgroundData)} */}
+                    {backgrounds.map((background: Background, idx: number) => {
+                      return (
+                        <CardMediaTop
+                          key={background.backgroundId}
+                          imageUrl="src/assets/images/backgrounds/library.png"
+                          name={background.backgroundName}
+                          chips={background.tags}
+                          onClick={() =>
+                            handleBackgroundClick(background.backgroundId)
+                          }
+                          variant="horizontal"
+                        />
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             </div>
           ) : (
-            <div className="text-center py-10">
-              <p className="text-gray-400">
-                아직 {character.name}와 채팅하지 않았어요.
-              </p>
+            <div>
+              {hasChatHistory ? (
+                <div className="flex flex-col gap-4">
+                  {backgrounds.map((background: Background) => (
+                    <CardMediaLeft
+                      key={background.backgroundId}
+                      imageUrl="src/assets/images/characters/character_1.png"
+                      name={background.backgroundName}
+                      description={background.description}
+                      onClick={() =>
+                        handleBackgroundClick(background.backgroundId)
+                      }
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="flex justify-center p-10">
+                  <p className="text-gray-400">
+                    아직 {character.name}와 채팅하지 않았어요.
+                  </p>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -17,8 +17,11 @@ interface ChatMessage {
 }
 
 const ChatPage: React.FC = () => {
-  const location = useLocation();
-  const { character } = location.state || {};
+  // const location = useLocation();
+  // const { character } = location.state || {};
+  const character = {
+    name: "반지호",
+  };
 
   const [messages] = useState<ChatMessage[]>([
     {

--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -18,11 +18,12 @@ interface PersonaOption {
 }
 
 const Personas: React.FC = () => {
-  const { setPersonaData } = useFlowStore();
+  const { characterId, setPersonaData } = useFlowStore();
   const [selectedPersona, setSelectedPersona] = useState("");
   const [name, setName] = useState("");
   const [gender, setGender] = useState("");
   const [personaDescription, setPersonaDescription] = useState("");
+
   const navigate = useNavigate();
 
   const personaData: PersonaOption[] = [
@@ -95,7 +96,7 @@ const Personas: React.FC = () => {
       };
 
       setPersonaData(personaInfo);
-      navigate(`/story`);
+      navigate(`/chat`, { state: { characterId } }); // ***수정필***
     }
   };
 

--- a/frontend/src/types/background.ts
+++ b/frontend/src/types/background.ts
@@ -14,6 +14,7 @@ export interface Background {
 }
 
 export interface BackgroundStep {
+  backgroundDescription: string;
   backgroundId: string;
   backgroundName: string;
   tags: string[];


### PR DESCRIPTION
## 📋 작업 내용

- [X] 대화 경험이 있는 user flow 수정 
- [X] 대화 기록 표시
- [X] 대화 기록 없는 경우 배경 설명 추가

### Refactoring
- [X] 탭 컨텐츠 분리

## 🎯 변경 사항

**기존:**
<img width="1187" height="641" alt="image" src="https://github.com/user-attachments/assets/c2486608-dbb8-4823-8053-99087781ceab" />

- 캐릭터 목록 -> 캐틱터 선택 -> 배경 목록 -> 배경 상세 및 선택 -> 페르소나 설정 -> 작품 완료 -> 채팅

**변경 후:**
<img width="996" height="758" alt="image" src="https://github.com/user-attachments/assets/49f9c176-7162-49bc-974a-ee6c3a06a9ab" />

- 캐릭터 목록 -> 캐틱터 선택 -> 배경 목록 -> 작품 상세 및 선택 -> 페르소나 설정 -> 채팅

## 🧪 테스트 방법

1. npm install
2. npm run docker:up
3. npm run dev
4. localhost:5173 페이지 내에서 플로우 따라서 채팅 실행


## 🔗 관련 이슈

- Closes #26

## ⚠️ 주의사항

<!-- 리뷰 시 특별히 확인해야 할 부분이나 배포 시 주의사항 -->
아직 스토리 API 연결이 완료되지 않아 내용 고려하지 말고 flow만 확인 부탁드립니다. 

## ✅ 체크리스트

- [ ] 코드 리뷰 완료